### PR TITLE
- adding settings for future features.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,14 @@ You are in charge, use them as you like!
 - :white_check_mark: While in the Add/remove extensions list, handle extension that uses i18n in their package.json (ie: %extension.displayName.title% becomes 'whatever value was set for this language or fallback to english in the package.nsl.[lang].json')
 - :white_check_mark: add a statusBar with the selected bundle name loaded or 'bundles ...' for many bundles or 'none' if no bundle is selected. Clicking it let you choose bundles to use for this project/workspace.
 - :white_check_mark: when creating a bundle, precheck the currently active extensions in VS Code.
-- :bulb: have an optional project file settings like a .mew file that would let a team configure a list of extensions to be used for this project, show a prompt that would allow you to install and load them (add a 'never ask me again'  option per project ?). Must handle TrustedWorkspace opt-in before doing anything (https://code.visualstudio.com/api/extension-guides/workspace-trust)
-- :bulb: add a setting 'tbd' set to true, in order to install (if necessary) and load the extensions specified in the .mew file automatically when opening the project/workspace.
-- :bulb: When extensions are installed while bundles are in use, let user choose if it should be added to the current bundles in use (add a setting to prevent prompt or automatically add it without asking)
+- :bulb: have an optional project file settings like a .mew file that would let a team configure a list of extensions to be used for this project, show a prompt that would allow you to install and load them. Must handle TrustedWorkspace opt-in before doing anything (https://code.visualstudio.com/api/extension-guides/workspace-trust)
+- :bulb: When extensions are installed while bundles are in use, let user choose if it should be added to the current bundles in use
 - :bulb: When extensions are uninstalled while bundles are in use, let user choose if it should be removed from the current bundles in use (add a setting to prevent prompt or automatically remove it without asking)
 - :bulb: Check if the extension 'Settings Sync' can keep our workspaces configuration of selected bundles across computers.
 - :bulb: investigate if all vscode windows that share the same active bundle, could be reloaded if this bundle was edited. (based on a setting)
 - :bulb: determine what to do when an extension state changes from the extension viewpanel
 - :bulb: add settings to specify :
     - should we reload window when active bundle is edited ? all windows that shares the same active bundle ?
-    - auto install and load extensions from .mewrc.json (never, prompt, load only, install only, always)
-    - extensions ignored list
 - :bulb: add localization on package. (very last priority)
 - :white_check_mark: add webpack to bundle vsix package.
 - :white_check_mark: Download automatically the right sqlite3 driver for your platform at first run, if it doesn't exists, notify user, he won't be able to use this extension at all.
@@ -41,25 +38,35 @@ You are in charge, use them as you like!
 
 ## Extension Settings
 
-- `mew.extensions.ignoredList`: extensions's state won't be changed by this extension, these extensions won't be listed when creating or editing bundles.
-- `mew.workspace.autoLoad`: if .mewrc.json exists in the folder/workspace:\
-  - `Prompt` Ask User if he wants to load extensions from .mewrc.json when opening a folder/workspace. choosing 'Don't ask me again' will change this setting to `Never` for this folder/workspace.\
-  - `Never` will neither load extensions when opening a folder/workspace. No prompt.\
-  - `Always` will load extensions from .mewrc.json automatically.\
-- `mew.workspace.autoInstall`: if .mewrc.json exists:\
-  - `Prompt` Ask user if he wants to install missing extensions listed in .mewrc.json when opening a folder/workspace. Choosing 'Don't ask me again' will change this setting to `Never` for this folder/workspace.\
-  - `Never` Doesn't install missing extensions and don't ask user for it.\
-  - `Always` will always installed missing extensions from .mewrc.json after opening a folder/workspace.\
-  - `mew.extensions.autoAdd`: When an extension is installed, automatically add it to bundles:
-    - `Never`: hide prompt and do nothing.
-    - `All active`: add the extension to all current active bundles automatically.
-    - `Choose your bundle(s)`: let user choose the bundles where the new extension will be added.
-    - `Prompt`: prompt for above choices.
-  - `mew.extensions.autoRemove`: When an extension is uninstalled, automatically remove it from bundles:
-    - `Never`: hide prompt and do nothing.
-    - `All active`: remove the extension from all current active bundles
-    - `Choose your bundle(s)`: let user choose the bundles where the new extension will be removed from.
-    - `Prompt`: prompt for above choices.
+- `mew.ignoredListExtensions`:\
+Extensions's state won't be changed by MEW, these extensions won't be listed when creating or editing bundles.
+- `mew.ignoreRemoteExtensions`: \
+Ignore VS Code Remote extensions. Same as the above ignoredList for:
+  - `ms-vscode-remote.remote-ssh`,
+  - `ms-vscode-remote.remote-ssh-edit`,
+  - `ms-vscode-remote.remote-wsl`,
+  - `ms-vscode-remote.remote-container`
+- `mew.workspace.autoLoad`: \
+When a .mewrc.json is found in the current workspace/folder, what should MEW do about loading those extensions ?
+  - `Ask you` Prompt: 'Some extensions to load were found inside the .mewrc.json, What should MEW do with it ?', Actions: 'Don't ask me again', 'Always load them', 'Load them & keep asking me'.
+  - `Keep calm & sleep` Let MEW sleeps. No future prompts.
+  - `Always do it` Always load extensions when opening a workspace or a folder.
+- `mew.workspace.autoInstall`: \
+When a .mewrc.json is found in the current workspace/folder, what should MEW do about installing those missing extensions ?
+  - `Ask you` Prompt: 'Some extensions listed inside the .mewrc.json aren't installed yet, Whatd should MEW do with it ?', Actions: 'Don't ask me again', 'Always Install them', 'Install them & keep asking me'.
+  - `Keep calm & sleep` Let MEW sleeps. No future prompts.
+  - `Always do it` will always installed missing extensions from .mewrc.json after opening a folder/workspace.
+- `mew.extensions.autoAdd`:
+Whenever an extension is installed, what should MEW do with it ?
+  - `Keep calm & sleep`: Let MEW sleeps. No future prompts.
+  - `Auto-edit all active`: Add the extension to all current active bundles automatically. No prompt.
+  - `Let you select bundle(s)`: Select the bundle(s) where you want to add the new extension.
+  - `Ask you`: Prompt 'Which bundle(s) should MEW add the extension ${extensionName} to ? 'Don't ask me again', 'All active' and 'Select', 'None'.
+- `mew.extensions.autoRemove`: \Whenever an extension is uninstalled, what should MEW do with it ?
+  - `Keep calm & sleep`: Let MEW sleeps. No future prompts.
+  - `Auto-edit all active`: Remove the extension from all current active bundles automatically. No prompt.
+  - `Let you select bundle(s)`: Select the bundle(s) where you want to remove the extension.
+  - `Ask you`: Prompt 'Which bundle(s) should MEW remove the extension ${extensionName} from ? 'Don't ask me again', 'All active' and 'Select', 'None'.
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,13 @@
   "extensionKind": [
     "ui"
   ],
+  "main": "./dist/extension.js",
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": false,
+      "description": ""
+    }
+  },
   "activationEvents": [
     "onCommand:mew.bundle.create",
     "onCommand:mew.extension.enable",
@@ -40,13 +47,6 @@
     "onCommand:mew.bundle.delete",
     "onStartupFinished"
   ],
-  "main": "./dist/extension.js",
-  "capabilities": {
-    "untrustedWorkspaces": {
-      "supported": false,
-      "description": ""
-    }
-  },
   "contributes": {
     "commands": [
       {
@@ -113,7 +113,7 @@
     "configuration": {
       "title": "MEW",
       "properties": {
-        "mew.extensions.ignoredList": {
+        "mew.ignoredListExtensions": {
           "type": "array",
           "default": [],
           "items": {
@@ -121,10 +121,66 @@
             "pattern": "^[a-z0-9-]+\\.[a-z0-9-]+[a-z]+$",
             "patternErrorMessage": "must follow the pattern `publisher.extension-name`. To find it you can right-click on the extension in the Extension panel and select 'Copy Extension Id'."
           },
-          "scope": "application",
-          "markdownDescription": "You won't be able to pick them for a bundle, their state won't be changed. Also 'enable (workspace)' or 'disable (workspace)' from extension view panel won't persist after selecting bundles.",
+          "scope": "window",
+          "markdownDescription": "You won't be able to pick them for a bundle, their state won't be changed.",
           "minItems": 0,
           "uniqueItems": true
+        },
+        "mew.ignoreRemoteExtensions": {
+          "type": "boolean",
+          "default": false,
+          "scope": "window",
+          "markdownDescription": "Ignore VS Code Remote extensions. merged into the above ignoredList for:\n- `ms-vscode-remote.remote-ssh`\n - `ms-vscode-remote.remote-ssh-edit`\n - `ms-vscode-remote.remote-wsl`\n - `ms-vscode-remote.remote-container`"
+        },
+        "mew.extensions.autoAdd": {
+          "type": "string",
+          "default": "Ask you",
+          "enum": ["Ask you", "Keep calm & sleep", "Auto-edit all active", "Let you select bundle(s)"],
+          "enumDescriptions": [
+            "Prompt 'Which bundle(s) should MEW add the extension ${extensionName} to ? 'Don't ask me again', 'All active' and 'Select', 'None'",
+            "Let MEW sleeps and do nothing. No Prompt",
+            "Add the extension to all current active bundles automatically. No prompt",
+            "Select the bundle(s) where you want to add the new extension."
+          ],
+          "scope": "window",
+          "markdownDescription": "Whenever an extension is installed, what should MEW do with it ?"
+        },
+        "mew.extensions.autoRemove": {
+          "type": "string",
+          "default": "Ask you",
+          "enum": ["Ask you", "Keep calm & sleep", "Auto-edit all active", "Let you select bundle(s)"],
+          "enumDescriptions": [
+            "Prompt 'Which bundle(s) should MEW remove the extension ${extensionName} from ? 'Don't ask me again', 'All active' and 'Select', 'None'",
+            "Let MEW sleeps. No Prompt",
+            "Remove the extension from all current active bundles automatically. No prompt",
+            "Select the bundle(s) where you want to remove the extension."
+          ],
+          "scope": "window",
+          "markdownDescription": "Whenever an extension is uninstalled, what should MEW do with it ?"
+        },
+        "mew.workspace.autoLoad": {
+          "type": "string",
+          "default": "Ask you",
+          "enum": ["Ask you", "Keep calm & sleep", "Always do it"],
+          "enumDescriptions": [
+            "Prompt: 'Some extensions to load were found inside the .mewrc.json, What should MEW do with it ?', Actions: 'Don't ask me again', 'Always load them', 'Load them & keep asking me'",
+            "Let MEW sleeps. No future prompts.",
+            "Always load extensions when opening a workspace or a folder. No future prompts."
+          ],
+          "scope": "window",
+          "markdownDescription": "When a .mewrc.json is found in the current workspace/folder, what should MEW do about loading those extensions ?"
+        },
+        "mew.workspace.autoInstall": {
+          "type": "string",
+          "default": "Ask you",
+          "enum": ["Ask you", "Keep calm & sleep", "Always do it"],
+          "enumDescriptions": [
+            "Prompt: 'Some extensions listed inside the .mewrc.json aren't installed yet, Whatd should MEW do with it ?', Actions: 'Don't ask me again', 'Always Install them', 'Install them & keep asking me'",
+            "Let MEW sleeps. No future prompts",
+            "Always install missing extensions when opening a workspace or a folder. No future prompts."
+          ],
+          "scope": "window",
+          "markdownDescription": "When a .mewrc.json is found in the current workspace/folder, what should MEW do about installing those missing extensions ?"
         }
       }
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,12 +17,13 @@ export class CommandsContribKey {
   public static readonly deleteBundle = "mew.bundle.delete";
   public static readonly disableExtension = "mew.extension.disable";
   public static readonly enableExtension = "mew.extension.enable";
-};
+}
 
 export class SettingsContribKey {
-  public static readonly ignoredList = "mew.extensions.ignoredList";
+  public static readonly ignoredList = "mew.ignoredListExtensions";
+  public static readonly ignoredRemote = "mew.ignoreRemoteExtensions";
   public static readonly autoLoad = "mew.workspace.autoLoad";
   public static readonly autoInstall = "mew.workspace.autoInstall";
-  public static readonly autoAdd = "mew.extension.autoAdd";
-  public static readonly autoRemove = "mew.extension.autoRemove";
-};
+  public static readonly autoAdd = "mew.extensions.autoAdd";
+  public static readonly autoRemove = "mew.extensions.autoRemove";
+}

--- a/src/services/settingService.ts
+++ b/src/services/settingService.ts
@@ -1,31 +1,76 @@
 ﻿import * as vscode from "vscode";
-import { Disposable } from "vscode";
 import { Service } from "typedi";
 import { SettingsContribKey } from "../constants";
 import ContextService from "./contextService";
+import { AutoTask, AutoTaskExtensions } from "../types";
 
 @Service()
-class SettingService implements Disposable {
+class SettingService implements vscode.Disposable {
+  private _ignoredExtensionsChangeEmitter = new vscode.EventEmitter<void>();
+  private _settings: { [k:string]: any } = {};
+  private static readonly _ignoredRemoteExtensions = [
+    "ms-vscode-remote.remote-ssh",
+    "ms-vscode-remote.remote-ssh-edit",
+    "ms-vscode-remote.remote-wsl",
+    "ms-vscode-remote.remote-container"
+  ];
+
   constructor(private _ctxService: ContextService) {
     this._ctxService.context.subscriptions.push(
-      vscode.workspace.onDidChangeConfiguration(this.configurationChanged)
+      vscode.workspace.onDidChangeConfiguration(this.configurationChanged, this)
     );
+
+    this.loadConfiguration();
   }
+
   dispose() {
+    this._settings = {};
+    this._ignoredExtensionsChangeEmitter.dispose();
+  }
+
+  private loadConfiguration() {
+    const contribConfigurations: string[] = Object.values(SettingsContribKey);
+    contribConfigurations.forEach((val) => {
+        this.processConfiguraton(val);
+    }, this);
   }
 
   private configurationChanged(event: vscode.ConfigurationChangeEvent) {
-    for (const settingKey of Object.values(SettingsContribKey))
-    {
-      if (event.affectsConfiguration(settingKey)) {
-        vscode.window.showInformationMessage(`Updated ${settingKey} setting`);
+    const contribConfigurations: string[] = Object.values(SettingsContribKey);
+    contribConfigurations.forEach((val) => {
+      if (event.affectsConfiguration(val)) {
+        this.processConfiguraton(val);
+        if (SettingsContribKey.ignoredList === val || SettingsContribKey.ignoredRemote === val) {
+          this._ignoredExtensionsChangeEmitter.fire();
+        }
       }
-    }
+    }, this);
+  }
+
+  private processConfiguraton(val: string) {
+    // first we split the section and the config
+    // ie: 'mew.ignoredListExtensions' becomes 'mew.extensions' and 'ignoreList'
+    const index = val.lastIndexOf('.');
+    const section = val.substring(0, index);
+    const config = val.substring(index+1, val.length);
+    this._settings[val] = vscode.workspace.getConfiguration(section).get(config);
   }
 
   public getUserIgnoredExtensions(): string[] {
-    return vscode.workspace.getConfiguration('mew.extensions').get('ignoredList') as string[];
+    const ignoredExtensions: string[] = this._settings[SettingsContribKey.ignoredList] ?? [];
+    if (this.ignoreRemoteExtensions === true) {
+      return [...ignoredExtensions, ...SettingService._ignoredRemoteExtensions];
+    }
+    return ignoredExtensions;
   }
+
+  public readonly onDidChangeIgnoredExtensions: vscode.Event<void> = this._ignoredExtensionsChangeEmitter.event;
+
+  public get ignoreRemoteExtensions(): boolean  { return this._settings[SettingsContribKey.ignoredRemote] ?? false; }
+  public get autoInstall(): AutoTask            { return this._settings[SettingsContribKey.autoInstall]   ?? AutoTask.prompt; }
+  public get autoRemove():  AutoTaskExtensions  { return this._settings[SettingsContribKey.autoRemove]    ?? AutoTaskExtensions.prompt; }
+  public get autoLoad():    AutoTask            { return this._settings[SettingsContribKey.autoLoad]      ?? AutoTask.prompt; }
+  public get autoAdd():     AutoTaskExtensions  { return this._settings[SettingsContribKey.autoAdd]       ?? AutoTaskExtensions.prompt; }
 }
 
 export default SettingService;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,3 @@
-export type ContributionReplaceToken = {
-  name: string,
-  type: any
-};
-
 export enum Scope {
   global,
   workspace
@@ -29,7 +24,6 @@ export type Extension = {
   id: string,
   uuid: string
 };
-
 
 export type PackageJson = {
 	name: string,
@@ -68,3 +62,16 @@ export type EditBundleOptions = {
   placeHolder: string,
   title: string
 };
+
+export enum AutoTask {
+  prompt = "Ask you",
+  never = "Keep calm & sleep",
+  always = "Always do it"
+}
+
+export enum AutoTaskExtensions {
+  prompt = "Ask you",
+  never = "Keep calm & sleep",
+  all = "Auto-edit all active",
+  choose = "Let you select bundle(s)"
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,7 +37,7 @@ export function loadJSON<T>(path: string) {
   return JSON.parse(readFileSync(path) as any) as T;
 }
 
-export function uniqueArray<T>(arrays: T[]) {
+export function uniqueArray<T>(...arrays: T[]) {
   return [...new Set([...arrays.map(o => JSON.stringify(o))])].map<T>(e => JSON.parse(e));
 }
 


### PR DESCRIPTION
- you can now ignore extensions without modifying previous bundles.
- extensions cache will reset when ignore list is modified in settings.
- see Readme, section Extension Settings for full list and detail